### PR TITLE
Update apca.js

### DIFF
--- a/src/apca.js
+++ b/src/apca.js
@@ -79,27 +79,24 @@ module.exports = function APCA(f, b) {
 	 * @typedef ContrastMinimums
 	 * @type {Number[]}
 	 * @description Minimum APCA contrast score required for font weights 100..900 in 100 increments
+	 * @version Main Font Lookup May 28 2022  Sorted by Font Size
 	 */
 	var Fonts = {
-		'12px': [null,null,null,100,94,87,80,80,80],
-	 	'14px': [null,null,null,90,84,77,70,70,70],
-		'16px': [null,null,110,80,77,72,60,60,60],
- 		'18px':[null,null,100,78,74,70,59,59,59],
-		'20px':[null,120,94,76,72,67,58,58,58],
-		'22px':[null,110,87,75,70,65,57,57,57],
- 		'24px':[null,100,80,74,66,60,56,56,56],
-		'26px':[null,96,78,72,65,59,55,55,55],
-		'28px':[null,92,76,70,64,58,54,54,52],
-		'30px':[null,88,74,68,62,57,53,52,50],
-		'32px':[null,84,72,66,60,56,52,50,48],
-		'36px':[120,80,70,64,58,54,50,48,46],
-		'40px':[114,77,68,62,57,52,48,46,44],
-		'44px':[108,74,66,60,55,50,46,44,42],
-		'48px':[100,70,65,58,53,48,44,42,40],
-		'56px':[95,67,64,56,51,46,42,40,40],
-		'64px':[90,65,62,54,49,44,40,40,40],
-		'72px':[85,63,60,52,47,42,40,40,40],
- 		'96px':[80,60,55,50,45,40,40,40,40],
+		'12px':[null,null,null,null,null,null,null,null,null],
+		'14px':[null,null,null,100,100,90,75,null,null],
+		'15px':[null,null,null,100,90,75,70,null,null],
+		'16px':[null,null,null,90,75,70,60,60,null],
+		'18px':[null,null,100,75,70,60,55,55,55],
+		'21px':[null,null,90,70,60,55,50,50,50],
+		'24px':[null,null,75,60,55,50,45,45,45],
+		'28px':[null,100,70,55,50,45,43,43,43],
+		'32px':[null,90,65,50,45,43,40,40,40],
+		'36px':[null,75,60,45,43,40,38,38,38],
+		'42px':[100,70,55,43,40,38,35,35,35],
+		'48px':[90,60,50,40,38,35,33,33,33],
+		'60px':[75,55,45,38,35,33,30,30,30],
+		'72px':[60,50,40,35,33,30,30,30,30],
+		'96px':[50,45,35,33,30,30,30,30,30],
 	};
 	// methods are added using defineProperty so they are not enumerable
 	Object.defineProperty(Fonts, 'list', {
@@ -176,8 +173,8 @@ module.exports = function APCA(f, b) {
 			lowOffset: 0.027,
 		},
 		reverse: {
-			background: 0.62,
-			foreground: 0.65,
+			background: 0.65,
+			foreground: 0.62,
 			lowThreshold: 0.035991,
 			lowFactor: 27.7847239587675,
 			lowOffset: 0.027,
@@ -221,7 +218,8 @@ module.exports = function APCA(f, b) {
 	/**
 	 * @private
 	 * @description Returns the luminance contrast ratio using the APCA method
-	 * @see {@link https://w3c.github.io/silver/guidelines/methods/Method-font-characteristic-contrast.html}
+	 * @see {@link https://git.apcacontrast.com/documentation/WhyAPCA}
+	 * @see {@link https://readtech.org/ARC/tests/visual-readability-contrast/?tn=criterion}
 	 * @return {Number}
 	 */
 	function score() {


### PR DESCRIPTION
Hello, I noticed some errata, and thought it would be easiest just to give you a pull request.

1) Exponents for reverse mode were reversed. FYI in both normal or reverse, the darkest color should have the highest exponent, which means that for reverse mode where the background is darkest should be 0.65, text or foreground 0.62, the difference is quite substantial.

2) Updated the look up table values to be in sync with the current version (May 28 2022)

3) Updated/added links in comments to current reference

Just as an FYI, the canonical repo for the public version is https://github.com/Myndex/apca-w3/ and there is also a NPM package by the same name, and it includes tests and additional functions.

There is a discussion forum at https://github.com/Myndex/SAPC-APCA/discussions

Please let me know if you have any questions.

Thank you for reading,

_Andrew Somers_      
_Color Scientist_      
_Myndex Research_      
_Creator of APCA_      
_W3C Invited Expert_      
_WCAG 3.0 Co-Author_